### PR TITLE
Fixed typo in readme example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here's how to invoke this example module in your projects
 
 ```hcl
 module vpn {
-  source = "https://github.com/DeployMode/terraform-aws-client-vpn.git?ref=master"
+  source = "git::https://github.com/DeployMode/terraform-aws-client-vpn.git?ref=master"
 
   context = module.this.context
 


### PR DESCRIPTION
# What
- The `git::` prefix is missing at the start of the module `source` causes Terraform to be unable to find and download the module.

# Why
- This change is required to update the documentation defect.

## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

